### PR TITLE
Use UILineBreakModeWordWrap instead of NSLineBreakByWordWrapping.

### DIFF
--- a/WKVerticalScrollBar/WKTextDemoView.m
+++ b/WKVerticalScrollBar/WKTextDemoView.m
@@ -51,7 +51,7 @@
         [_textLabel setBackgroundColor:[UIColor clearColor]];
         [_textLabel setFont:[UIFont fontWithName:@"Baskerville" size:18.0f]];
         [_textLabel setNumberOfLines:0];
-        [_textLabel setLineBreakMode:NSLineBreakByWordWrapping];
+        [_textLabel setLineBreakMode:UILineBreakModeWordWrap];
         [_scrollView addSubview:_textLabel];
 
         // NOTE: Make sure vertical scroll bar is on top of the scroll view


### PR DESCRIPTION
The demo uses NSLineBreakByWordWrapping to wrap the sample text, which is for use in OSX apps. UILineBreakModeWordWrap should be used for iOS apps.
