### PR TITLE
Add initWithCoder: initialization code path

### DIFF
--- a/WKVerticalScrollBar.podspec
+++ b/WKVerticalScrollBar.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.summary      = 'A traditional-style scrollbar for iOS that integrates with existing UIScrollView or UIScrollView subclasses.'
   s.homepage     = 'https://github.com/litl/WKVerticalScrollBar'
   s.author       = { 'Brad Taylor' => 'btaylor@litl.com' }
-  s.source       = { :git => 'https://github.com/litl/WKVerticalScrollBar.git', :tag => 'version/0.3.2' }
+  s.source       = { :git => 'https://github.com/litl/WKVerticalScrollBar.git' }
 
   s.source_files = 'WKVerticalScrollBar/WKVerticalScrollBar.{h,m}'
   

--- a/WKVerticalScrollBar.podspec
+++ b/WKVerticalScrollBar.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name         = 'WKVerticalScrollBar'
+  s.version      = '0.3.2'
+  s.license      = 'MIT'
+  s.platform     = :ios
+
+  s.summary      = 'A traditional-style scrollbar for iOS that integrates with existing UIScrollView or UIScrollView subclasses.'
+  s.homepage     = 'https://github.com/litl/WKVerticalScrollBar'
+  s.author       = { 'Brad Taylor' => 'btaylor@litl.com' }
+  s.source       = { :git => 'https://github.com/litl/WKVerticalScrollBar.git', :tag => 'version/0.3.2' }
+
+  s.source_files = 'WKVerticalScrollBar/WKVerticalScrollBar.{h,m}'
+  
+  s.frameworks   = 'QuartzCore'
+end

--- a/WKVerticalScrollBar/WKVerticalScrollBar.m
+++ b/WKVerticalScrollBar/WKVerticalScrollBar.m
@@ -29,6 +29,10 @@
 
 #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
 
+@interface WKVerticalScrollBar ()
+- (void)commonInit;
+@end
+
 @implementation WKVerticalScrollBar
 
 @synthesize handleWidth = _handleWidth;
@@ -40,27 +44,40 @@
 - (id)initWithFrame:(CGRect)frame
 {
     if ((self = [super initWithFrame:frame])) {
-        _handleWidth = 5.0f;
-        _handleSelectedWidth = 15.0f;
-        _handleHitWidth = 44.0f;
-        _handleMinimumHeight = 70.0f;
-        
-        _handleCornerRadius = _handleWidth / 2;
-        _handleSelectedCornerRadius = _handleSelectedWidth / 2;
-        
-        handleHitArea = CGRectZero;
-        
-        normalColor = [[UIColor colorWithWhite:0.6f alpha:1.0f] retain];
-        selectedColor = [[UIColor colorWithWhite:0.4f alpha:1.0f] retain];
-
-        handle = [[CALayer alloc] init];
-        [handle setCornerRadius:_handleCornerRadius];
-        [handle setAnchorPoint:CGPointMake(1.0f, 0.0f)];
-        [handle setFrame:CGRectMake(0, 0, _handleWidth, 0)];
-        [handle setBackgroundColor:[normalColor CGColor]];
-        [[self layer] addSublayer:handle];
+        [self commonInit];
     }
     return self;
+}
+
+- (id)initWithCoder:(NSCoder *)aDecoder
+{
+    if ((self = [super initWithCoder:aDecoder])) {
+        [self commonInit];
+    }
+    return self;
+}
+
+- (void)commonInit
+{
+    _handleWidth = 5.0f;
+    _handleSelectedWidth = 15.0f;
+    _handleHitWidth = 44.0f;
+    _handleMinimumHeight = 70.0f;
+    
+    _handleCornerRadius = _handleWidth / 2;
+    _handleSelectedCornerRadius = _handleSelectedWidth / 2;
+    
+    handleHitArea = CGRectZero;
+    
+    normalColor = [[UIColor colorWithWhite:0.6f alpha:1.0f] retain];
+    selectedColor = [[UIColor colorWithWhite:0.4f alpha:1.0f] retain];
+    
+    handle = [[CALayer alloc] init];
+    [handle setCornerRadius:_handleCornerRadius];
+    [handle setAnchorPoint:CGPointMake(1.0f, 0.0f)];
+    [handle setFrame:CGRectMake(0, 0, _handleWidth, 0)];
+    [handle setBackgroundColor:[normalColor CGColor]];
+    [[self layer] addSublayer:handle];
 }
 
 - (void)dealloc


### PR DESCRIPTION
This pull request adds an initialization code path via `initWithCoder:` for use when the scroll bar has been added to the view hierarchy via a XIB/Storyboard.

There is a secondary commit that adds the Cocoapod podspec to the project. It is currently necessary to have a podspec in the project to enable installation via Cocoapods from a fork/branch by overriding the :git and :branch options. 
