### PR TITLE
Woven fix dealloc crash

### DIFF
--- a/WKVerticalScrollBar/WKVerticalScrollBar.m
+++ b/WKVerticalScrollBar/WKVerticalScrollBar.m
@@ -123,9 +123,10 @@
 
 - (void)setHandleAccessoryView:(UIView *)handleAccessoryView
 {
+    [handleAccessoryView retain];
     [_handleAccessoryView removeFromSuperview];
     [_handleAccessoryView release];
-    _handleAccessoryView = [handleAccessoryView retain];
+    _handleAccessoryView = handleAccessoryView;
     
     [_handleAccessoryView setAlpha:0.0f];
     [self addSubview:_handleAccessoryView];
@@ -135,11 +136,13 @@
 - (void)setHandleColor:(UIColor *)color forState:(UIControlState)state
 {
     if (state == UIControlStateNormal) {
+        [color retain];
         [normalColor release];
-        normalColor = [color retain];
+        normalColor = color;
     } else if (state == UIControlStateSelected) {
+        [color retain];
         [selectedColor release];
-        selectedColor = [color retain];
+        selectedColor = color;
     }
 }
 


### PR DESCRIPTION
This attempts to fix a crash, from possibly assigning handleAccessoryView to itself. It gets released before it can be retained. Normal and selected colors looked similar so changed the setter there as well. https://rink.hockeyapp.net/manage/apps/2740/crash_reasons/6739660?&no_iphone_ui=true#
