### PR TITLE
Add property to specify space between accessory and handle

### DIFF
--- a/WKVerticalScrollBar/WKVerticalScrollBar.h
+++ b/WKVerticalScrollBar/WKVerticalScrollBar.h
@@ -49,6 +49,7 @@
 @property (nonatomic, readwrite) CGFloat handleWidth;
 @property (nonatomic, readwrite) CGFloat handleHitWidth;
 @property (nonatomic, readwrite) CGFloat handleSelectedWidth;
+@property (nonatomic, readwrite) CGFloat accessorySeparationFromHandle;
 
 @property (nonatomic, readwrite) CGFloat handleCornerRadius;
 @property (nonatomic, readwrite) CGFloat handleSelectedCornerRadius;

--- a/WKVerticalScrollBar/WKVerticalScrollBar.m
+++ b/WKVerticalScrollBar/WKVerticalScrollBar.m
@@ -219,7 +219,8 @@
     
     // Center the accessory view to the left of the handle
     CGRect accessoryFrame = [_handleAccessoryView frame];
-    [_handleAccessoryView setCenter:CGPointMake(bounds.size.width - _handleHitWidth - (accessoryFrame.size.width / 2),
+    CGFloat offsetFromHandle = _accessorySeparationFromHandle ?: _handleHitWidth;
+    [_handleAccessoryView setCenter:CGPointMake(bounds.size.width - offsetFromHandle - (accessoryFrame.size.width / 2),
                                                 handleY + (handleHeight / 2))];
     
     handleHitArea = CGRectMake(bounds.size.width - _handleHitWidth, handleY,


### PR DESCRIPTION
This lets us set a different spacing than the current hitWidth. We can make the space small and hitWidth larger as requested by design.
