### PR TITLE
Allow setting an explicit handle height

### DIFF
--- a/WKVerticalScrollBar.podspec
+++ b/WKVerticalScrollBar.podspec
@@ -12,4 +12,6 @@ Pod::Spec.new do |s|
   s.source_files = 'WKVerticalScrollBar/WKVerticalScrollBar.{h,m}'
   
   s.frameworks   = 'QuartzCore'
+
+  s.requires_arc = false
 end

--- a/WKVerticalScrollBar/WKVerticalScrollBar.h
+++ b/WKVerticalScrollBar/WKVerticalScrollBar.h
@@ -55,6 +55,18 @@
 
 @property (nonatomic, readwrite) CGFloat handleMinimumHeight;
 
+/**
+ *  Whether to use a custom height for the handle.
+ *
+ *  @param false Handle height proportional to the visible portion of the scrollview content
+ *  @param true  Use custom handle height
+ */
+@property (nonatomic, readwrite) BOOL useExplicitHandleHeight;
+/**
+ * Custom height of the handle, if useExplicitHandleHeight is enabled.
+ */
+@property (nonatomic, readwrite) CGFloat explicitHandleHeight;
+
 @property (nonatomic, readwrite, retain) UIScrollView *scrollView;
 @property (nonatomic, readwrite, retain) UIView *handleAccessoryView;
 

--- a/WKVerticalScrollBar/WKVerticalScrollBar.m
+++ b/WKVerticalScrollBar/WKVerticalScrollBar.m
@@ -40,6 +40,8 @@
 @synthesize handleSelectedWidth = _handleSelectedWidth;
 
 @synthesize handleMinimumHeight = _handleMinimumHeight;
+@synthesize useExplicitHandleHeight = _useExplicitHandleHeight;
+@synthesize explicitHandleHeight = _explicitHandleHeight;
 
 - (id)initWithFrame:(CGRect)frame
 {
@@ -215,10 +217,7 @@
     CGFloat scrollValue = (contentHeight - frameHeight == 0) ? 0
                            : [_scrollView contentOffset].y / (contentHeight - frameHeight);
     
-    // Set handleHeight proportionally to how much content is being currently viewed
-    CGFloat handleHeight = CLAMP((frameHeight / contentHeight) * bounds.size.height,
-                                 _handleMinimumHeight, bounds.size.height);
-    
+    CGFloat handleHeight = [self handleHeight];
     [handle setOpacity:(handleHeight == bounds.size.height) ? 0.0f : 1.0f];
     
     // Not only move the handle, but also shift where the position maps on to the handle,
@@ -239,6 +238,22 @@
                                _handleHitWidth, handleHeight);
     
     [CATransaction commit];
+}
+
+- (CGFloat)handleHeight
+{
+  if (_useExplicitHandleHeight) {
+    return _explicitHandleHeight;
+  } else {
+    CGFloat contentHeight = [_scrollView contentSize].height;
+    CGFloat frameHeight = [_scrollView frame].size.height;
+    CGRect bounds = [self bounds];
+  
+    // Set handleHeight proportionally to how much content is being currently viewed
+    return CLAMP((frameHeight/ contentHeight) * bounds.size.height,
+                 _handleMinimumHeight,
+                 bounds.size.height);
+  }
 }
 
 - (BOOL)handleVisible
@@ -315,8 +330,8 @@
     CGSize contentSize = [_scrollView contentSize];
     CGPoint contentOffset = [_scrollView contentOffset];
     CGFloat frameHeight = [_scrollView frame].size.height;
-    CGFloat deltaY = ((point.y - lastTouchPoint.y) / [self bounds].size.height)
-                     * [_scrollView contentSize].height;
+    CGFloat deltaY = (point.y - lastTouchPoint.y) / (self.bounds.size.height-[self handleHeight])
+                     * (contentSize.height-frameHeight);
     
     [_scrollView setContentOffset:CGPointMake(contentOffset.x,  CLAMP(contentOffset.y + deltaY,
                                                                       0, contentSize.height - frameHeight))

--- a/WKVerticalScrollBar/WKVerticalScrollBar.m
+++ b/WKVerticalScrollBar/WKVerticalScrollBar.m
@@ -157,6 +157,15 @@
     return _handleCornerRadius;
 }
 
+- (void)setHandleWidth:(CGFloat)handleWidth
+{
+    _handleWidth = handleWidth;
+  
+    CGRect handleFrame = handle.frame;
+    handleFrame.size.width = handleWidth;
+    handle.frame = handleFrame;
+}
+
 - (void)setHandleCornerRadius:(CGFloat)handleCornerRadius
 {
     _handleCornerRadius = handleCornerRadius;

--- a/WKVerticalScrollBar/WKVerticalScrollBar.m
+++ b/WKVerticalScrollBar/WKVerticalScrollBar.m
@@ -139,10 +139,16 @@
         [color retain];
         [normalColor release];
         normalColor = color;
+        if (!handleDragged) {
+            [handle setBackgroundColor: color.CGColor];
+        }
     } else if (state == UIControlStateSelected) {
         [color retain];
         [selectedColor release];
         selectedColor = color;
+        if (handleDragged) {
+            [handle setBackgroundColor: color.CGColor];
+        }
     }
 }
 


### PR DESCRIPTION
I am using WKVerticalScrollBar with a round button as the scroll handle like so:
<img width="34" alt="screen shot 2015-11-10 at 00 33 50" src="https://cloud.githubusercontent.com/assets/4222754/11050020/d3b779cc-8742-11e5-9fc8-ab1871594de4.png">

To allow setting custom handle dimensions, I added an `explicitHandleHeight` and `useExplicitHandleHeight` attribute to `WKVerticalScrollBar`.

Other changes included in this pull request:
- Immediatly update the handle color and handle width when setting them. Previously these changes only took effect after dragging the handle for the first time.
- Explicitly specify WKVerticalScrollBar as a non-ARC project in the podspec.
