### PR TITLE
Update podspec to not require ARC

### DIFF
--- a/WKVerticalScrollBar.podspec
+++ b/WKVerticalScrollBar.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/litl/WKVerticalScrollBar.git' }
 
   s.source_files = 'WKVerticalScrollBar/WKVerticalScrollBar.{h,m}'
+  s.requires_arc = false
   
   s.frameworks   = 'QuartzCore'
 end


### PR DESCRIPTION
Admittedly, I'm not the most well-versed on Podspec best practices, but I was able to get this pod to build and run on my ARC-based project with this Podspec setting.
