### PR TITLE
Reset handle bounds when setting handle width

### DIFF
--- a/WKVerticalScrollBar/WKVerticalScrollBar.m
+++ b/WKVerticalScrollBar/WKVerticalScrollBar.m
@@ -174,6 +174,19 @@
     }
 }
 
+- (CGFloat)handleWidth
+{
+    return _handleWidth;
+}
+
+- (void)setHandleWidth:(CGFloat)handleWidth
+{
+    _handleWidth = handleWidth;
+    if (!handleDragged) {
+        [handle setBounds:CGRectMake(0, 0, _handleWidth, [handle bounds].size.height)];
+    }
+}
+
 - (void)layoutSubviews
 {
     [super layoutSubviews];


### PR DESCRIPTION
I was having an issue where setting `handleWidth` didn't take into effect until after the user touched the scroll bar.

I updated the `handleWidth` setter to reset the `handle` bounds immediately, so that the size is seen right away.
